### PR TITLE
JP-5-remove: 글씨체 app.tsx에서 삭제

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,10 +4,6 @@ export default function Document() {
   return (
     <Html lang="ko">
       <Head>
-        <link
-          rel="stylesheet"
-          href="https://hangeul.pstatic.net/hangeul_static/webfont/NanumSquareNeo/NanumSquareNeoTTF-bRg.eot"
-        />
         <link rel="icon" href="/arbaba.png" type="image/x-icon" />
         <meta
           name="description"


### PR DESCRIPTION
## #️⃣연관된 이슈

> JP-5

## 📝작업 내용

> app,.tsx에 있는 font가 fcp 12초정도 먹음 -> 지웠습니다. =

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
