### PR TITLE
콘솔내 찍히는 리액트 에러 수정

### DIFF
--- a/src/components/Post/PostCard.tsx
+++ b/src/components/Post/PostCard.tsx
@@ -6,6 +6,7 @@ interface PostCardProps {
   shopData: Shop;
   className?: string;
   bgNone?: boolean;
+  isPassed?: boolean;
 }
 
 export default function PostCard({
@@ -14,10 +15,9 @@ export default function PostCard({
   className,
   bgNone,
 }: PostCardProps) {
-  const { hourlyPay, startsAt, closed, workhour } = noticeData;
+  const { hourlyPay, startsAt, closed, workhour, isPassed } = noticeData;
   const { name, address1, imageUrl, originalHourlyPay } = shopData;
 
-  const isPassed = new Date() > new Date(startsAt);
   const currentPostState: NoticeStatus = closed
     ? 'closed'
     : isPassed

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,7 +18,16 @@ export default function Home(data: NoticeListResponseData) {
 export const getServerSideProps: GetServerSideProps = async () => {
   const data = await getNoticeList({ limit: 6 });
 
+  // 서버 사이드에서 isPassed 계산
+  const noticesWithIsPassed = data.notices.map((notice: Notice) => ({
+    ...notice,
+    isPassed: new Date() > new Date(notice.startsAt),
+  }));
+
   return {
-    props: data,
+    props: {
+      ...data,
+      notices: noticesWithIsPassed,
+    },
   };
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,7 +18,11 @@ export default function Home(data: NoticeListResponseData) {
 export const getServerSideProps: GetServerSideProps = async () => {
   const data = await getNoticeList({ limit: 6 });
 
-  // 서버 사이드에서 isPassed 계산
+  if (!data.notices) {
+    // notices 값이 없을 경우 빈 배열로 초기화
+    data.notices = [];
+  }
+
   const noticesWithIsPassed = data.notices.map((notice: Notice) => ({
     ...notice,
     isPassed: new Date() > new Date(notice.startsAt),

--- a/src/types/Notice.d.ts
+++ b/src/types/Notice.d.ts
@@ -5,6 +5,7 @@ interface NoticeBase {
   workhour: number;
   description: string;
   closed: boolean;
+  isPassed: boolean;
 }
 
 interface currentUserApplication {


### PR DESCRIPTION
## #️⃣연관된 이슈

>JP-6

## 📝작업 내용

>리액트  에러 수정했습니다.

#425는 서버사이드 하이드레이션 오류
- 서버사이드 렌더링 하는 파일 내에 new Date()가 들어있어서 뜨던 오류입니다. newDate 외부로 빼서 작성했습니다.
#423은  추후 작성 예정
<img width="661" alt="스크린샷 2024-10-24 오후 5 02 01" src="https://github.com/user-attachments/assets/afdb269f-0df5-4660-aa42-a778342fdd79">


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
